### PR TITLE
Restore /feeds/index.rss2 and verify it in CI

### DIFF
--- a/.github/scripts/verify-feed.py
+++ b/.github/scripts/verify-feed.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Fail if public/feeds/index.rss2 is missing, malformed, or empty."""
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+feed = Path("public/feeds/index.rss2")
+if not feed.is_file() or feed.stat().st_size == 0:
+    sys.exit(f"::error::{feed} is missing or empty")
+
+root = ET.parse(feed).getroot()
+if root.tag != "rss":
+    sys.exit(f"::error::{feed} root is <{root.tag}>, expected <rss>")
+
+items = root.findall("./channel/item")
+print(f"RSS items: {len(items)}")
+if not items:
+    sys.exit(f"::error::{feed} has no <item> entries")

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,6 +42,15 @@ jobs:
 
       - name: Build
         run: hugo --minify
+      - name: Verify RSS feed
+        run: |
+          set -euo pipefail
+          feed=public/feeds/index.rss2
+          test -s "$feed" || { echo "::error::$feed is missing or empty"; exit 1; }
+          xmllint --noout "$feed"
+          items=$(xmllint --xpath 'count(/rss/channel/item)' "$feed")
+          echo "RSS items: $items"
+          [ "$items" -gt 0 ] || { echo "::error::$feed has no <item> entries"; exit 1; }
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,21 +43,7 @@ jobs:
       - name: Build
         run: hugo --minify
       - name: Verify RSS feed
-        run: |
-          python3 - <<'PY'
-          import sys, xml.etree.ElementTree as ET
-          from pathlib import Path
-          feed = Path("public/feeds/index.rss2")
-          if not feed.is_file() or feed.stat().st_size == 0:
-              sys.exit(f"::error::{feed} is missing or empty")
-          root = ET.parse(feed).getroot()
-          if root.tag != "rss":
-              sys.exit(f"::error::{feed} root is <{root.tag}>, expected <rss>")
-          items = root.findall("./channel/item")
-          print(f"RSS items: {len(items)}")
-          if not items:
-              sys.exit(f"::error::{feed} has no <item> entries")
-          PY
+        run: .github/scripts/verify-feed.py
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,13 +44,20 @@ jobs:
         run: hugo --minify
       - name: Verify RSS feed
         run: |
-          set -euo pipefail
-          feed=public/feeds/index.rss2
-          test -s "$feed" || { echo "::error::$feed is missing or empty"; exit 1; }
-          xmllint --noout "$feed"
-          items=$(xmllint --xpath 'count(/rss/channel/item)' "$feed")
-          echo "RSS items: $items"
-          [ "$items" -gt 0 ] || { echo "::error::$feed has no <item> entries"; exit 1; }
+          python3 - <<'PY'
+          import sys, xml.etree.ElementTree as ET
+          from pathlib import Path
+          feed = Path("public/feeds/index.rss2")
+          if not feed.is_file() or feed.stat().st_size == 0:
+              sys.exit(f"::error::{feed} is missing or empty")
+          root = ET.parse(feed).getroot()
+          if root.tag != "rss":
+              sys.exit(f"::error::{feed} root is <{root.tag}>, expected <rss>")
+          items = root.findall("./channel/item")
+          print(f"RSS items: {len(items)}")
+          if not items:
+              sys.exit(f"::error::{feed} has no <item> entries")
+          PY
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -24,7 +24,7 @@ mediaTypes:
       - "rss2"
 
 outputFormats:
-  rss:
+  RSS:
     mediaType: "application/rss+xml"
     path: feeds/
     noUgly: false
@@ -32,11 +32,9 @@ outputFormats:
 outputs:
   home:
     - html
-    - rss
+    - RSS
   page:
     - html
-  rss:
-    - rss
   section:
     - html
   taxonomy:

--- a/layouts/_default/rss.rss2
+++ b/layouts/_default/rss.rss2
@@ -1,0 +1,29 @@
+{{- $pages := where site.RegularPages "Type" "post" -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.Title }}</title>
+    <link>{{ site.BaseURL }}</link>
+    <description>Recent content on {{ site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.Locale }}</language>
+    {{- with site.Copyright }}
+    <copyright>{{ . }}</copyright>
+    {{- end }}
+    {{- with (index $pages.ByLastmod.Reverse 0) }}
+    <lastBuildDate>{{ .Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType.Type | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Content | transform.XMLEscape | safeHTML }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
Hugo stopped emitting the RSS feed when the output format was renamed
to lowercase rss in e468f00; the embedded RSS template also doesn't
apply when the format's media-type suffix is the custom rss2 instead
of xml, so a layout file is required.

Rename the format back to RSS, drop the dead outputs.rss stanza, and
add layouts/_default/rss.rss2 so Hugo writes feeds/index.rss2 with
every post.

Add a "Verify RSS feed" workflow step that fails the build if the
feed is missing, malformed, or item-less.

Closes grml/grml.org#149

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
